### PR TITLE
Fix URL params for resizing snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ You can also pass parameters to the `imgix_url` helper like so:
 Which would result in the following HTML:
 
 ```html
-<img src="https://assets.imgix.net/images/bear.jpg?w=400&h300" />
+<img src="https://assets.imgix.net/images/bear.jpg?w=400&h=300" />
 ```
 
 ### Configuration


### PR DESCRIPTION
I _think_ the example URL for resizing the [:bear:'s h parameter](https://www.imgix.com/docs/reference/size#param-h) is missing an <kbd>=</kbd> ?

<img src="https://cloud.githubusercontent.com/assets/121322/10656979/1b233b24-783a-11e5-8dea-0a10950e9c2e.png" width="50%">

Cheers,
  Lee :beers:
