### PR TITLE
Add multi-source support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,31 @@ Then include `jekyll-imgix` in the `gems:` section of your `_config.yml` file:
 gems: [jekyll/imgix]
 ```
 
+## Configuration
+
+jekyll-imgix requires a configuration block in your `_config.yml`:
+
+```yaml
+imgix:
+  source: assets.imgix.net # Your imgix source address
+  secure_url_token: FACEBEEF12 # (optional) The Secure URL Token associated with your source
+  include_library_param: true  # (optional) If `true` all the URLs will include `ixlib` parameter
+```
+
+### Multi-source configuration
+
+In addition to the standard configuration flags, the following options can be used to serve images across different sources.
+
+```yaml
+imgix:
+  sources:  # imgix source-secure_url_token key-value pairs.
+    assets.imgix.net: FACEBEEF12
+    assets2.imgix.net:            # Will generate unsigned URLs
+  default_source: assets.imgix.net  # (optional) specify a default source for generating URLs.
+```
+
+Note: `sources` and `source` *cannot* be used together.
+
 ## Usage
 
 **jekyll-imgix does not do anything unless JEKYLL_ENV is set to production**. For example,
@@ -53,15 +78,23 @@ Which would result in the following HTML:
 <img src="https://assets.imgix.net/images/bear.jpg?w=400&h=300" />
 ```
 
-### Configuration
+### Multi-source usage
 
-jekyll-imgix requires a configuration block in your `_config.yml`:
+To use jekyll-imgix in a multi-source setup:
 
-```yaml
-imgix:
-  source: assets.imgix.net # Your imgix source address
-  secure_url_token: FACEBEEF12 # (optional) The Secure URL Token associated with your source
+```html
+<img src={{ "/images/bear.jpg" | imgix_url: "assets2.imgix.net", w: 400, h: 300 }} />
+<img src={{ "/images/bear.jpg" | imgix_url: w: 400, h: 300 }} />  <!-- will use default_source from config -->
 ```
+
+Which would generate:
+
+```html
+<img src="https://assets2.imgix.net/images/bear.jpg?w=400&h=300" />
+<img src="https://assets.imgix.net/images/bear.jpg?w=400&h=300" />
+```
+
+In absence of correctly configured `default_source`, `imgix_url` will report `RuntimeError` if it's used without specifying a valid source.
 
 ## Contributing
 
@@ -72,3 +105,5 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/imgix/
 
 The gem is available as open source under the terms of the [BSD-2-Clause License](http://opensource.org/licenses/BSD-2-Clause).
 
+## Code of Conduct
+Users contributing to or participating in the development of this project are subject to the terms of imgix's [Code of Conduct](https://github.com/imgix/code-of-conduct).

--- a/lib/jekyll/imgix.rb
+++ b/lib/jekyll/imgix.rb
@@ -4,36 +4,88 @@ require "liquid"
 
 module Jekyll
   module Imgix
-    def imgix_url(raw, opts={})
-      return raw unless production?
-      verify_config_present!
-      client.path(raw).to_url(opts)
+    def imgix_url(*args)
+      case args.size
+      when 1
+        path = args[0]
+        source = nil
+        options = {}
+      when 2
+        if args[0].is_a?(String) && args[1].is_a?(Hash)
+          path = args[0]
+          source = nil
+          options = args[1]
+        elsif args[0].is_a?(String) && args[1].is_a?(String)
+          path = args[0]
+          source = args[1]
+          options = {}
+        else
+          raise RuntimeError.new("path and source must be of type String; options must be of type Hash")
+        end
+      when 3
+        path = args[0]
+        source = args[1]
+        options = args[2]
+      else
+        raise RuntimeError.new('path missing')
+      end
+
+      return path unless production?
+
+      verify_config!
+      imgix_client(source).path(path).to_url(options)
     end
 
   private
 
-    def verify_config_present!
-      unless @context.registers[:site].config['imgix']
+    DEFAULT_OPTS = {
+      library_param: "jekyll",
+      library_version: VERSION,
+      use_https: true
+    }.freeze
+
+
+    def verify_config!
+      config = @context.registers[:site].config['imgix']
+      unless config
         raise StandardError.new("No 'imgix' section present in _config.yml. Please see https://github.com/imgix/jekyll-imgix for configuration instructions")
+      end
+      if !(config['source'] || config['sources'])
+        raise StandardError.new("One of 'source', 'sources' is required")
+      end
+      if (config['source'] && config['sources'])
+        raise StandardError.new("'source' and 'sources' can't be used together")
       end
     end
 
-    def client
-      return @client if @client
-
-      opts = default_opts.dup
-      opts[:secure_url_token] = secure_url_token if secure_url_token
-      opts[:include_library_param] = include_library_param?
-      @client = ::Imgix::Client.new(opts)
+    def imgix_client(src)
+      begin
+        return imgix_clients.fetch(src)
+      rescue KeyError
+        raise RuntimeError.new("Unknown source '#{src}'")
+      end
     end
 
-    def default_opts
-      {
-        host: source,
-        library_param: "jekyll",
-        library_version: VERSION,
-        use_https: true
-      }
+    def imgix_clients
+      return @imgix_clients if @imgix_clients
+
+      opts = DEFAULT_OPTS.dup
+      opts[:secure_url_token] = secure_url_token if secure_url_token
+      opts[:include_library_param] = include_library_param?
+
+      @imgix_clients = {}
+      sources.map do |source, token|
+        opts[:host] = source
+        opts[:secure_url_token] = token
+        @imgix_clients[source] = ::Imgix::Client.new(opts)
+      end
+
+      begin
+        @imgix_clients[nil] = @imgix_clients.fetch(default_source || source)
+      rescue
+      end
+
+      @imgix_clients
     end
 
     def production?
@@ -50,6 +102,18 @@ module Jekyll
 
     def source
       ix_config.fetch('source', nil)
+    end
+
+    def sources
+      begin
+        return ix_config.fetch('sources')
+      rescue
+        return { ix_config.fetch('source') => secure_url_token }
+      end
+    end
+
+    def default_source
+      ix_config.fetch('default_source', nil)
     end
 
     def secure_url_token

--- a/spec/jekyll/imgix_spec.rb
+++ b/spec/jekyll/imgix_spec.rb
@@ -1,37 +1,311 @@
 require 'spec_helper'
 
 describe Jekyll::Imgix do
-  let(:source) { "assets.imgix.net" }
-  let(:template) do
-    Class.new do
-      include Jekyll::Imgix
-    end.new
-  end
 
   it 'has a version number' do
     expect(Jekyll::Imgix::VERSION).not_to be nil
   end
 
-  context 'development mode' do
-    let(:url) { "https://google.com/cats.gif" }
-
-    before do
-      expect(Jekyll).to receive(:env).and_return("development")
+  context 'single source' do
+    let(:source) { "assets.imgix.net" }
+    let(:template) do
+      Class.new do
+        include Jekyll::Imgix
+      end.new
     end
 
-    it 'passes values through' do
-      expect(template.imgix_url(url)).to eq url
+    context 'development mode' do
+      let(:url) { "https://google.com/cats.gif" }
+
+      before do
+        expect(Jekyll).to receive(:env).and_return("development")
+      end
+
+      it 'passes values through' do
+        expect(template.imgix_url(url)).to eq url
+      end
+    end
+
+    context 'production mode' do
+      let(:path) { "/cats.gif" }
+      let(:config) do
+        {
+          'imgix' => {
+            'source' => source
+          }
+        }
+      end
+      let(:registers) do
+        {
+          site: double("Object", config: config)
+        }
+      end
+      let(:context) {double("Object", registers: registers) }
+
+      before do
+        expect(Jekyll).to receive(:env).and_return("production")
+        template.instance_variable_set(:@context, context)
+      end
+
+      it 'passes values through' do
+        expect(template.imgix_url(path)).to eq "https://assets.imgix.net/cats.gif?ixlib=jekyll-#{Jekyll::Imgix::VERSION}"
+      end
+
+      it 'URL encodes param keys' do
+        expect(template.imgix_url('demo.png', {'hello world' => 'interesting'})).to eq "https://assets.imgix.net/demo.png?ixlib=jekyll-#{Jekyll::Imgix::VERSION}&hello%20world=interesting"
+      end
+
+      it 'URL encodes param values' do
+        expect(template.imgix_url('demo.png', {hello_world: '/foo"> <script>alert("hacked")</script><'})).to eq "https://assets.imgix.net/demo.png?ixlib=jekyll-#{Jekyll::Imgix::VERSION}&hello_world=%2Ffoo%22%3E%20%3Cscript%3Ealert%28%22hacked%22%29%3C%2Fscript%3E%3C"
+      end
+
+      it 'Base64 encodes Base64 param variants' do
+        expect(template.imgix_url('~text', {txt64: 'I cannøt belîév∑ it wors! 😱'})).to eq "https://assets.imgix.net/~text?ixlib=jekyll-#{Jekyll::Imgix::VERSION}&txt64=SSBjYW5uw7h0IGJlbMOuw6l24oiRIGl0IHdvcu-jv3MhIPCfmLE"
+      end
+
+      it 'adds parameters' do
+        expect(template.imgix_url(path, { w: 400, h: 300 })).to eq "https://assets.imgix.net/cats.gif?ixlib=jekyll-#{Jekyll::Imgix::VERSION}&w=400&h=300"
+      end
+
+      context 'secure_url_token specified' do
+        let(:config) do
+          {
+            'imgix' => {
+              'source' => source,
+              'secure_url_token' => 'FACEBEEF',
+              'include_library_param' => false
+            }
+          }
+        end
+
+        it 'signs the URL' do
+          expect(template.imgix_url(path, { w: 400, h: 300 })).to eq "https://assets.imgix.net/cats.gif?w=400&h=300&s=e7e25321c9e007f36a8a4610662f32aa"
+        end
+      end
+
     end
   end
 
-  context 'production mode' do
+  context 'multiple sources' do
+    context 'with default_source' do
+      let(:sources) { { "assets.imgix.net" => nil, "assets2.imgix.net" => nil } }
+      let(:default_source) { "assets.imgix.net" }
+      let(:template) do
+        Class.new do
+          include Jekyll::Imgix
+        end.new
+      end
+
+      context 'development mode' do
+        let(:url) { "https://google.com/cats.gif" }
+
+        before do
+          expect(Jekyll).to receive(:env).and_return("development")
+        end
+
+        describe 'passes values through' do
+          it 'with no source specified' do
+            expect(template.imgix_url(url)).to eq url
+          end
+
+          it 'with explicit source specified' do
+            expect(template.imgix_url(url, 'assets2.imgix.net')).to eq url
+          end
+        end
+      end
+
+      context 'production mode' do
+        let(:path) { "/cats.gif" }
+        let(:config) do
+          {
+            'imgix' => {
+              'sources' => sources,
+              'default_source' => default_source,
+            }
+          }
+        end
+        let(:registers) do
+          {
+            site: double("Object", config: config)
+          }
+        end
+        let(:context) {double("Object", registers: registers) }
+
+        before do
+          expect(Jekyll).to receive(:env).and_return("production")
+          template.instance_variable_set(:@context, context)
+        end
+
+        describe 'passes values through' do
+          it 'with no source specified' do
+            expect(template.imgix_url(path)).to eq "https://assets.imgix.net/cats.gif?ixlib=jekyll-#{Jekyll::Imgix::VERSION}"
+          end
+
+          it 'with explicit source specified' do
+            expect(template.imgix_url(path, 'assets2.imgix.net')).to eq "https://assets2.imgix.net/cats.gif?ixlib=jekyll-#{Jekyll::Imgix::VERSION}"
+          end
+
+          it 'with unknown source specified' do
+            expect {
+              template.imgix_url(path, 'foo.bar')
+            }.to raise_error(RuntimeError)
+          end
+        end
+
+        describe 'adds parameters' do
+          it 'with no source specified' do
+            expect(template.imgix_url(path, { w: 400, h: 300 })).to eq "https://assets.imgix.net/cats.gif?ixlib=jekyll-#{Jekyll::Imgix::VERSION}&w=400&h=300"
+          end
+
+          it 'with explicit source specified' do
+            expect(template.imgix_url(path, 'assets2.imgix.net', { w: 400, h: 300 })).to eq "https://assets2.imgix.net/cats.gif?ixlib=jekyll-#{Jekyll::Imgix::VERSION}&w=400&h=300"
+          end
+
+          it 'with unknown source specified' do
+            expect {
+              template.imgix_url(path, 'foo.bar', { w: 400, h: 300 })
+            }.to raise_error(RuntimeError)
+          end
+        end
+
+        context 'secure_url_token specified' do
+          let(:config) do
+            {
+              'imgix' => {
+                'include_library_param' => false,
+                'default_source' => 'assets.imgix.net',
+                'sources' => {
+                  'assets.imgix.net' => 'FACEBEEF',
+                  'assets2.imgix.net' => 'foobarbaz',
+                }
+              }
+            }
+          end
+
+          describe 'signs the URL' do
+            it 'with no source specified' do
+              expect(template.imgix_url(path, { w: 400, h: 300 })).to eq "https://assets.imgix.net/cats.gif?w=400&h=300&s=e7e25321c9e007f36a8a4610662f32aa"
+            end
+
+            it 'with explicit source specified' do
+              expect(template.imgix_url(path, 'assets2.imgix.net', { w: 400, h: 300 })).to eq "https://assets2.imgix.net/cats.gif?w=400&h=300&s=a47059971f1a8fb0c8bee75331feee26"
+            end
+
+            it 'with unknown source specified' do
+              expect {
+                template.imgix_url(path, 'foo.bar', { w: 400, h: 300 })
+              }.to raise_error(RuntimeError)
+            end
+          end
+        end
+      end
+    end
+
+    context 'without default_source' do
+      let(:sources) { { "assets.imgix.net" => nil, "assets2.imgix.net" => nil } }
+      let(:template) do
+        Class.new do
+          include Jekyll::Imgix
+        end.new
+      end
+
+      context 'development mode' do
+        let(:url) { "https://google.com/cats.gif" }
+
+        before do
+          expect(Jekyll).to receive(:env).and_return("development")
+        end
+
+        describe 'passes values through' do
+          it 'with no source specified' do
+            expect(template.imgix_url(url)).to eq url
+          end
+
+          it 'with explicit source specified' do
+            expect(template.imgix_url(url, 'assets2.imgix.net')).to eq url
+          end
+        end
+      end
+
+      context 'production mode' do
+        let(:path) { "/cats.gif" }
+        let(:config) do
+          {
+            'imgix' => {
+              'sources' => sources,
+            }
+          }
+        end
+        let(:registers) do
+          {
+            site: double("Object", config: config)
+          }
+        end
+        let(:context) {double("Object", registers: registers) }
+
+        before do
+          expect(Jekyll).to receive(:env).and_return("production")
+          template.instance_variable_set(:@context, context)
+        end
+
+        describe 'passes values through' do
+          it 'with no source specified' do
+            expect {
+              template.imgix_url(path)
+            }.to raise_error(RuntimeError)
+          end
+
+          it 'with explicit source specified' do
+            expect{
+              template.imgix_url(path, 'assets2.imgix.net')
+            }.not_to raise_error
+          end
+
+          it 'with unknown source specified' do
+            expect {
+              template.imgix_url(path, 'foo.bar')
+            }.to raise_error(RuntimeError)
+          end
+        end
+
+        describe 'adds parameters' do
+          it 'with no source specified' do
+            expect {
+              template.imgix_url(path, { w: 400, h: 300 })
+            }.to raise_error(RuntimeError)
+          end
+
+          it 'with explicit source specified' do
+            expect {
+              template.imgix_url(path, 'assets2.imgix.net', { w: 400, h: 300 })
+            }.not_to raise_error
+          end
+
+          it 'with unknown source specified' do
+            expect {
+              template.imgix_url(path, 'foo.bar', { w: 400, h: 300 })
+            }.to raise_error(RuntimeError)
+          end
+        end
+      end
+    end
+  end
+
+  context 'config validation' do
     let(:path) { "/cats.gif" }
+    let(:source) { "assets.imgix.net" }
     let(:config) do
       {
         'imgix' => {
           'source' => source
         }
       }
+    end
+
+    let(:template) do
+      Class.new do
+        include Jekyll::Imgix
+      end.new
     end
     let(:registers) do
       {
@@ -45,57 +319,38 @@ describe Jekyll::Imgix do
       template.instance_variable_set(:@context, context)
     end
 
-    it 'passes values through' do
-      expect(template.imgix_url(path)).to eq "https://assets.imgix.net/cats.gif?ixlib=jekyll-#{Jekyll::Imgix::VERSION}"
-    end
-
-    it 'URL encodes param keys' do
-      expect(template.imgix_url('demo.png', {'hello world' => 'interesting'})).to eq "https://assets.imgix.net/demo.png?ixlib=jekyll-#{Jekyll::Imgix::VERSION}&hello%20world=interesting"
-    end
-
-    it 'URL encodes param values' do
-      expect(template.imgix_url('demo.png', {hello_world: '/foo"> <script>alert("hacked")</script><'})).to eq "https://assets.imgix.net/demo.png?ixlib=jekyll-#{Jekyll::Imgix::VERSION}&hello_world=%2Ffoo%22%3E%20%3Cscript%3Ealert%28%22hacked%22%29%3C%2Fscript%3E%3C"
-    end
-
-    it 'Base64 encodes Base64 param variants' do
-      expect(template.imgix_url('~text', {txt64: 'I cannøt belîév∑ it wors! 😱'})).to eq "https://assets.imgix.net/~text?ixlib=jekyll-#{Jekyll::Imgix::VERSION}&txt64=SSBjYW5uw7h0IGJlbMOuw6l24oiRIGl0IHdvcu-jv3MhIPCfmLE"
-    end
-
-    it 'adds parameters' do
-      expect(template.imgix_url(path, { w: 400, h: 300 })).to eq "https://assets.imgix.net/cats.gif?ixlib=jekyll-#{Jekyll::Imgix::VERSION}&w=400&h=300"
-    end
-
-    context 'secure_url_token specified' do
-      let(:config) do
-        {
-          'imgix' => {
-            'source' => source,
-            'secure_url_token' => 'FACEBEEF',
-            'include_library_param' => false
-          }
-        }
-      end
-
-      # We jump through these hoops because including the version number will
-      # mess with the signature when the version number is incremented
-      before do
-        expect(template).to receive(:default_opts).and_return({
-          host: source,
-          include_library_param: false,
-          use_https: true
-        })
-      end
-
-      it 'signs the URL' do
-        expect(template.imgix_url(path, { w: 400, h: 300 })).to eq "https://assets.imgix.net/cats.gif?w=400&h=300&s=e7e25321c9e007f36a8a4610662f32aa"
-      end
-    end
-
     context ':imgix not set in _config.yml' do
       let(:config) { {} }
-
       it 'raises an exception when :imgix is not present in _config.yml' do
-        expect{ template.imgix_url(path) }.to raise_error(StandardError, "No 'imgix' section present in _config.yml. Please see https://github.com/imgix/jekyll-imgix for configuration instructions")
+        expect {
+          template.imgix_url(path)
+        }.to raise_error(StandardError, "No 'imgix' section present in _config.yml. Please see https://github.com/imgix/jekyll-imgix for configuration instructions")
+      end
+    end
+
+    context ':source and :sources both set' do
+      let(:config) { {
+          'imgix' => {
+          'source' => 'assets.imgix.net',
+          'sources' => {
+            'assets.imgix.net' => nil,
+            'assets2.imgix.net' => nil,
+          }
+        }
+      } }
+      it 'raises an exception when :source and :source are both present in _config.yml' do
+        expect {
+          template.imgix_url(path)
+        }.to raise_error(StandardError)
+      end
+    end
+
+    context ':source and :source both not set' do
+      let(:config) { { 'imgix': {} } }
+      it 'raises an exception when :source and :source both are not present in _config.yml' do
+        expect {
+          template.imgix_url(path)
+        }.to raise_error(StandardError)
       end
     end
   end


### PR DESCRIPTION
This PR adds support for generating URLs across multiple imgix sources.

Multiple sources can be specified through the following configuration:
```yaml
imgix:
  sources:  # imgix source-secure_url_token key-value pairs.
    assets.imgix.net: FACEBEEF12
    assets2.imgix.net:            # Will generate unsigned URLs
  default_source: assets.imgix.net  # (optional) specify a default source for generating URLs.
```
and used in the following manner:
```html
<img src={{ "/images/bear.jpg" | imgix_url: "assets2.imgix.net", w: 400, h: 300 }} />
<img src={{ "/images/bear.jpg" | imgix_url: w: 400, h: 300 }} />
```

This is a **completely backwards compatible** change.