### PR TITLE
docs: change gem version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 `jekyll-imgix` is a plugin for integrating [imgix](https://www.imgix.com) into Jekyll sites.
 
-[![Gem Version](https://badge.fury.io/rb/jekyll-imgix.svg)](https://rubygems.org/gems/jekyll-imgix)
+[![Gem Version](https://img.shields.io/gem/v/jekyll-imgix.svg)](https://rubygems.org/gems/jekyll-imgix)
 [![Build Status](https://travis-ci.org/imgix/jekyll-imgix.svg)](https://travis-ci.org/imgix/jekyll-imgix)
 ![Downloads](https://img.shields.io/gem/dt/jekyll-imgix)
 [![License](https://img.shields.io/github/license/imgix/drift)](https://github.com/imgix/jekyll-imgix/blob/master/LICENSE)
@@ -13,9 +13,9 @@
 
 - [Installation](#installation)
 - [Configuration](#configuration)
-  - [Multi Source Configuration](#multi-source-configuration)
+  - [Multi-source configuration](#multi-source-configuration)
 - [Usage](#usage)
-  - [Multi Source Usage](#multi-source-usage)
+  - [Multi-source usage](#multi-source-usage)
 - [Contributing](#contributing)
 - [Code of Conduct](#code-of-conduct)
 


### PR DESCRIPTION
As a follow up to #12, changes the gem version badge.

<img width="452" alt="jekyll-readme-pt2" src="https://user-images.githubusercontent.com/15919091/71496574-fc4a9700-2821-11ea-94fa-89ab7968f2ba.png">
