### PR TITLE
docs: update `gems` key to `plugins` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ group :jekyll_plugins do
 end
 ```
 
-Then include `jekyll-imgix` in the `gems:` section of your `_config.yml` file:
+Then include `jekyll-imgix` in the `plugins:` section of your `_config.yml` file:
 
 ``` yaml
-gems: [jekyll/imgix]
+plugins: [jekyll/imgix]
 ```
 
 ## Configuration


### PR DESCRIPTION
From Jekyll version 3.5 `gems` key has been updated to `plugins`.